### PR TITLE
Match kvm_enable_sgx_provisioning() prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,128 @@
+Master
+======
+The *master* branch generally tracks the most recent release and will occasionally be rebased without warning.  Using a [tagged release](#releases) is recommended for most users.
+
+Introduction
+============
+
+## About
+
+Intel® Software Guard Extensions (Intel® SGX) is an Intel technology designed to increase the security of application code and data.  This repository hosts preliminary Qemu patches to support SGX virtualization on KVM.  Because SGX is built on hardware features that cannot be emulated in software, virtualizing SGX requires support in KVM and in the host kernel.  The requesite Linux and KVM changes can be found in the [KVM SGX Tree](https://github.com/intel/kvm-sgx).
+
+Utilizing SGX in the guest requires a kernel/OS with SGX support, e.g. a kernel buit using the [SGX Linux Development Tree](https://github.com/jsakkine-intel/linux-sgx.git) or the [KVM SGX Tree](https://github.com/intel/kvm-sgx).  Running KVM SGX as the guest kernel allows nested virtualization of SGX (obviously requires a compatible Qemu build).  An alternative option to recompiling your guest kernel is to use the out-of-tree SGX driver (compiles as a kernel module) on top of a non-SGX kernel, e.g. your distro's standard kernel.
+
+  - [KVM SGX Tree](https://github.com/intel/kvm-sgx)
+  - [SGX Linux Development Tree](https://github.com/jsakkine-intel/linux-sgx.git)
+  - [SGX Out-of-Tree Driver for Linux](https://github.com/intel/linux-sgx-driver)
+  - [SGX Homepage](https://software.intel.com/sgx)
+  - [SGX SDK](https://software.intel.com/sgx-sdk)
+  - [Linux SDK Downloads](https://01.org/intel-software-guard-extensions/downloads)
+
+## Caveat Emptor
+
+SGX virtualization on Qemu/KVM is under active development.  The patches in this repository are intended for experimental purposes only, they are not mature enough for production use.
+
+This readme assumes that the reader is familiar with Intel® SGX, Qemu, KVM and Linux, and has experience building Qemu and the Linux kernel.  Only the aspects of SGX virtualization directly related to Qemu are covered, please see the kvm-sgx repository for additional details on virtualizing SGX.
+
+
+Qemu SGX
+========
+
+## Enabling
+
+Due to its myriad dependencies, SGX is currently not listed as supported in any of Qemu's built-in CPU configuration.  To expose SGX (and SGX Launch Control) to a guest, you must either use `-cpu host` to pass-through the host CPU model, or explicitly enable SGX when using a built-in CPU model, e.g. via `-cpu <model>,+sgx` or `-cpu <model>,+sgx,+sgxlc`.
+
+## Virtual EPC
+
+By default, Qemu does not assign EPC to a VM, i.e. fully enabling SGX in a VM requires explicit allocation of EPC to the VM.  Similar to other specialized memory types, e.g. hugetlbfs, EPC is exposed as a memory backend.  For a number of reasons, a EPC memory backend can only be realized via an 'sgx-epc' device.  Standard memory backend options such as prealloc are supported by EPC.
+
+SGX EPC is enumerated through CPUID, i.e. EPC "devices" need to be realized prior to realizing the vCPUs themselves, which occurs long before generic devices are parsed and realized.  Because of this, 'sgx-epc' devices must be created via the dedicated -sgx-epc command, i.e. cannot be created through the generic -devices command.  On the plus side, this limitation means that EPC does not require -maxmem as EPC is not treated as {cold,hot}plugged memory.
+
+Qemu does not artificially restrict the number of EPC sections exposed to a guest, e.g. Qemu will happily allow you to create 64 1M EPC sections.  Be aware that some kernels may not recognize all EPC sections, e.g. the Linux SGX driver is hardwired to support only 8 EPC sections.
+
+The following Qemu snippet creates two EPC sections, with 64M pre-allocated to the VM and an additional 28M mapped but not allocated:
+
+`-object memory-backend-epc,id=mem1,size=64M,prealloc -sgx-epc id=epc1,memdev=mem1 -object memory-backend-epc,id=mem2,size=28M -sgx-epc id=epc2,memdev=mem2`
+
+Note: The size and location of the virtual EPC are far less restricted compared to physical EPC.  Because physical EPC is protected via range registers, the size of the physical EPC must be a power of two (though software sees a subset of the full EPC, e.g. 92M or 128M) and the EPC must be naturally aligned.  KVM SGX's virtual EPC is purely a software construct and only requires the size and location to be page aligned.  Qemu enforces the EPC size is a multiple of 4k and will ensure the base of the EPC is 4k aligned.  To simplify the implementation, EPC is always located above 4g in the guest physical address space.
+
+## Migration
+
+Migration of SGX enabled VMs is allowed, but because EPC memory is encrypted with an ephemereal key that is tied to the underlying hardware, migrating a VM will result in the loss of EPC data, similar to loss of EPC data on system suspend.
+
+## CPUID
+
+All SGX sub-features enumerated through CPUID, e.g. SGX2, MISCSELECT, ATTRIBUTES, etc... can be restricted via CPUID flags.  Be aware that enforcing restriction of MISCSELECT, ATTRIBUTES and XFRM requires intercepting ECREATE, i.e. may marginally reduce SGX performance in the guest.  All SGX sub-features controlled via -cpu are prefixed with "sgx", e.g.:
+
+```
+$ qemu-system-x86_64 -cpu help | xargs printf "%s\n" | grep sgx
+sgx
+sgx-debug
+sgx-encls-c
+sgx-enclv
+sgx-exinfo
+sgx-kss
+sgx-mode64
+sgx-provisionkey
+sgx-tokenkey
+sgx1
+sgx2
+sgxlc
+```
+
+The following Qemu snippet passes through the host CPU (and host physical address width) but restricts access to the provision and EINIT token keys:
+
+`-cpu host,host-phys-bits,-sgx-provisionkey,-sgx-tokenkey`
+
+Note: SGX sub-features cannot be emulated, i.e. sub-features that are not present in hardware cannot be forced on via '-cpu'.
+
+## Launch Control
+
+Qemu SGX support for Launch Control (LC) is passive, in the sense that it does not actively change the LC configuration.  Qemu SGX provides the user the ability to set/clear the CPUID flag (and by extension the associated IA32_FEATURE_CONTROL MSR bit in fw_cfg) and saves/restores the LE Hash MSRs when getting/putting guest state, but Qemu does not add new controls to directly modify the LC configuration.  Similar to hardware behavior, locking the LC configuration to a non-Intel value is left to guest firmware.
+
+## Feature Control
+
+Qemu SGX updates the `etc/msr_feature_control` fw_cfg entry to set the SGX (bit 18) and SGX LC (bit 17) flags based on their respective CPUID support, i.e. existing guest firmware will automatically set SGX and SGX LC accordingly, assuming said firmware supports fw_cfg.msr_feature_control.
+
+Releases
+========
+  * sgx-v4.0.0-r2
+      - Fix a conflict with VFIO that broke device pass-through.
+      - Compatible with KVM SGX kernel release sgx-v5.6.0-rc5-r1
+
+  * sgx-v4.0.0-r1
+      - Rebase to upstream release v4.0.0
+      - Support exposing PROVISIONKEY to guest.
+      - Compatible with KVM SGX kernel release sgx-v5.6.0-rc5-r1
+
+  * sgx-v3.1.0-r1
+      - Rebase to upstream release v3.1.0
+      - Expose EPC via memory backend and sgx-epc device
+      - Support restricting SGX sub-features via CPUID flags
+      - Compatible with KVM SGX kernel release sgx-v5.0.0-r1
+
+  * sgx-v3.0.0-r2
+      - Set virtual EPC using KVM_SET_USER_MEMORY_REGION with KVM_MEM_SGX_EPC flag
+      - Compatible with KVM SGX kernel release sgx-v4.18.3-r2 and sgx-v4.19.1-r1
+
+  * sgx-v3.0.0-r1
+      - Rebase to upstream release v3.0.0
+      - Set virtual EPC using new ioctl KVM_X86_SET_SGX_EPC
+      - Compatible with KVM SGX kernel release sgx-v4.18.3-r1
+
+  * sgx-v2.11.1-r2
+      - Add user control of leaf 0x12 SGX feature bits, e.g. SGX2, SGX_ENCLV, etc...
+      - Update README to clarify -cpu usage
+      - Compatible with KVM SGX kernel releases sgx-v4.14.28-r1, sgx-v4.15.11-r1 and sgx-v4.17.3-r1
+
+  * sgx-v2.11.1-r1
+      - Rebase to upstream release v2.11.1
+      - Compatible with KVM SGX kernel releases sgx-v4.14.28-r1, sgx-v4.15.11-r1 and sgx-v4.17.3-r1
+
+  * sgx-v2.10.1-r1
+      - Change KVM_CAP_X86_VIRTUAL_EPC to 200 to avoid additional changes in the near future.
+      - Compatible with KVM SGX kernel releases sgx-v4.14.28-r1, sgx-v4.15.11-r1 and sgx-v4.17.3-r1
+
+  * sgx-v2.10.1-alpha
+      - Initial release (previously was the master branch)
+      - KVM_CAP_X86_VIRTUAL_EPC is 150 in this release!  As is, this Qemu will only work with kernel release sgx-v4.14.0-alpha.

--- a/hw/i386/acpi-build.c
+++ b/hw/i386/acpi-build.c
@@ -2189,6 +2189,28 @@ build_dsdt(GArray *table_data, BIOSLinker *linker,
         aml_append(sb_scope, dev);
     }
 
+    if (pcms->sgx_epc) {
+        uint64_t epc_base = pcms->sgx_epc->base;
+        uint64_t epc_size = pcms->sgx_epc->size;
+
+        dev = aml_device("EPC");
+        aml_append(dev, aml_name_decl("_HID", aml_eisaid("INT0E0C")));
+        aml_append(dev, aml_name_decl("_STR",
+                                      aml_unicode("Enclave Page Cache 1.0")));
+        crs = aml_resource_template();
+        aml_append(crs,
+                   aml_qword_memory(AML_POS_DECODE, AML_MIN_FIXED,
+                                    AML_MAX_FIXED, AML_NON_CACHEABLE,
+                                    AML_READ_WRITE, 0, epc_base,
+                                    epc_base + epc_size - 1, 0, epc_size));
+        aml_append(dev, aml_name_decl("_CRS", crs));
+
+        method = aml_method("_STA", 0, AML_NOTSERIALIZED);
+        aml_append(method, aml_return(aml_int(0x0f)));
+        aml_append(dev, method);
+
+        aml_append(sb_scope, dev);
+    }
     aml_append(dsdt, sb_scope);
 
     /* copy AML table into ACPI tables blob and patch header there */

--- a/hw/i386/pc.c
+++ b/hw/i386/pc.c
@@ -1583,7 +1583,7 @@ static void pc_build_feature_control_file(PCMachineState *pcms)
     MachineState *ms = MACHINE(pcms);
     X86CPU *cpu = X86_CPU(ms->possible_cpus->cpus[0].cpu);
     CPUX86State *env = &cpu->env;
-    uint32_t unused, ecx, edx;
+    uint32_t unused, ebx, ecx, edx;
     uint64_t feature_control_bits = 0;
     uint64_t *val;
 
@@ -1596,6 +1596,14 @@ static void pc_build_feature_control_file(PCMachineState *pcms)
         (CPUID_EXT2_MCE | CPUID_EXT2_MCA) &&
         (env->mcg_cap & MCG_LMCE_P)) {
         feature_control_bits |= FEATURE_CONTROL_LMCE;
+    }
+
+    cpu_x86_cpuid(env, 0x7, 0, &unused, &ebx, &ecx, &unused);
+    if (ebx & CPUID_7_0_EBX_SGX) {
+        feature_control_bits |= FEATURE_CONTROL_SGX;
+    }
+    if (ecx & CPUID_7_0_ECX_SGX_LC) {
+        feature_control_bits |= FEATURE_CONTROL_SGX_LC;
     }
 
     if (!feature_control_bits) {

--- a/hw/i386/pc.c
+++ b/hw/i386/pc.c
@@ -1763,6 +1763,9 @@ void pc_memory_init(PCMachineState *pcms,
                                     ram_above_4g);
         e820_add_entry(0x100000000ULL, pcms->above_4g_mem_size, E820_RAM);
     }
+    if (pcms->sgx_epc != NULL) {
+        e820_add_entry(pcms->sgx_epc->base, pcms->sgx_epc->size, E820_RESERVED);
+    }
 
     if (!pcmc->has_reserved_memory &&
         (machine->ram_slots ||

--- a/hw/i386/pc.c
+++ b/hw/i386/pc.c
@@ -1795,8 +1795,14 @@ void pc_memory_init(PCMachineState *pcms,
             exit(EXIT_FAILURE);
         }
 
+        if (sgx_epc_above_4g(pcms->sgx_epc)) {
+            machine->device_memory->base = sgx_epc_above_4g_end(pcms->sgx_epc);
+        } else {
+            machine->device_memory->base =
+                0x100000000ULL + pcms->above_4g_mem_size;
+        }
         machine->device_memory->base =
-            ROUND_UP(0x100000000ULL + pcms->above_4g_mem_size, 1 * GiB);
+            ROUND_UP(machine->device_memory->base, 1 * GiB);
 
         if (pcmc->enforce_aligned_dimm) {
             /* size device region assuming 1G page max alignment per slot */
@@ -1875,6 +1881,8 @@ uint64_t pc_pci_hole64_start(void)
         if (!pcmc->broken_reserved_end) {
             hole64_start += memory_region_size(&ms->device_memory->mr);
         }
+    } else if (sgx_epc_above_4g(pcms->sgx_epc)) {
+            hole64_start = sgx_epc_above_4g_end(pcms->sgx_epc);
     } else {
         hole64_start = 0x100000000ULL + pcms->above_4g_mem_size;
     }

--- a/hw/i386/pc_piix.c
+++ b/hw/i386/pc_piix.c
@@ -148,6 +148,9 @@ static void pc_init1(MachineState *machine,
             pcms->above_4g_mem_size = 0;
             pcms->below_4g_mem_size = machine->ram_size;
         }
+        if (pcmc->pci_enabled) {
+            pc_machine_init_sgx_epc(pcms);
+        }
     }
 
     pc_cpus_init(pcms);

--- a/hw/i386/pc_q35.c
+++ b/hw/i386/pc_q35.c
@@ -178,6 +178,8 @@ static void pc_q35_init(MachineState *machine)
 
     if (xen_enabled()) {
         xen_hvm_init(pcms, &ram_memory);
+    } else {
+        pc_machine_init_sgx_epc(pcms);
     }
 
     pc_cpus_init(pcms);

--- a/include/hw/i386/sgx-epc.h
+++ b/include/hw/i386/sgx-epc.h
@@ -60,4 +60,16 @@ extern int sgx_epc_enabled;
 void pc_machine_init_sgx_epc(PCMachineState *pcms);
 int sgx_epc_get_section(int section_nr, uint64_t *addr, uint64_t *size);
 
+static inline bool sgx_epc_above_4g(SGXEPCState *sgx_epc)
+{
+    return sgx_epc != NULL;
+}
+
+static inline uint64_t sgx_epc_above_4g_end(SGXEPCState *sgx_epc)
+{
+    assert(sgx_epc != NULL && sgx_epc->base >= 0x100000000ULL);
+
+    return sgx_epc->base + sgx_epc->size;
+}
+
 #endif

--- a/target/i386/cpu.c
+++ b/target/i386/cpu.c
@@ -5185,6 +5185,11 @@ static void x86_cpu_expand_features(X86CPU *cpu, Error **errp)
         if (sev_enabled()) {
             x86_cpu_adjust_level(cpu, &env->cpuid_min_xlevel, 0x8000001F);
         }
+
+        /* SGX requires CPUID[0x12] for EPC enumeration */
+        if (env->features[FEAT_7_0_EBX] & CPUID_7_0_EBX_SGX) {
+            x86_cpu_adjust_level(cpu, &env->cpuid_min_level, 0x12);
+        }
     }
 
     /* Set cpuid_*level* based on cpuid_min_*level, if not explicitly set */

--- a/target/i386/cpu.c
+++ b/target/i386/cpu.c
@@ -4528,7 +4528,10 @@ void cpu_x86_cpuid(CPUX86State *env, uint32_t index, uint32_t count,
             *ecx |= XSTATE_FP_MASK | XSTATE_SSE_MASK;
 
             /* Access to PROVISIONKEY requires additional credentials. */
-            *eax &= ~(1U << 4);
+            if ((*eax & (1U << 4)) &&
+                !kvm_enable_sgx_provisioning(cs->kvm_state)) {
+                *eax &= ~(1U << 4);
+            }
         }
 #endif
         break;

--- a/target/i386/kvm-stub.c
+++ b/target/i386/kvm-stub.c
@@ -39,11 +39,6 @@ uint32_t kvm_arch_get_supported_cpuid(KVMState *env, uint32_t function,
 {
     abort();
 }
-
-bool kvm_enable_sgx_provisioning(void)
-{
-    return false;
-}
 #endif
 
 bool kvm_hv_vpindex_settable(void)

--- a/target/i386/kvm-stub.c
+++ b/target/i386/kvm-stub.c
@@ -39,6 +39,11 @@ uint32_t kvm_arch_get_supported_cpuid(KVMState *env, uint32_t function,
 {
     abort();
 }
+
+bool kvm_enable_sgx_provisioning(void)
+{
+    return false;
+}
 #endif
 
 bool kvm_hv_vpindex_settable(void)

--- a/target/i386/kvm.c
+++ b/target/i386/kvm.c
@@ -1110,6 +1110,25 @@ int kvm_arch_init_vcpu(CPUState *cs)
                 c = &cpuid_data.entries[cpuid_i++];
             }
             break;
+        case 0x12:
+            for (j = 0; ; j++) {
+                c->function = i;
+                c->flags = KVM_CPUID_FLAG_SIGNIFCANT_INDEX;
+                c->index = j;
+                cpu_x86_cpuid(env, i, j, &c->eax, &c->ebx, &c->ecx, &c->edx);
+
+                if (j > 1 && (c->eax & 0xf) != 1) {
+                    break;
+                }
+
+                if (cpuid_i == KVM_MAX_CPUID_ENTRIES) {
+                    fprintf(stderr, "cpuid_data is full, no space for "
+                                "cpuid(eax:0x12,ecx:0x%x)\n", j);
+                    abort();
+                }
+                c = &cpuid_data.entries[cpuid_i++];
+            }
+            break;
         case 0x14: {
             uint32_t times;
 

--- a/target/i386/kvm.c
+++ b/target/i386/kvm.c
@@ -3604,6 +3604,35 @@ void kvm_arch_update_guest_debug(CPUState *cpu, struct kvm_guest_debug *dbg)
     }
 }
 
+static bool has_sgx_provisioning;
+
+static bool __kvm_enable_sgx_provisioning(KVMState *s)
+{
+    int fd, ret;
+
+    if (!kvm_vm_check_extension(s, KVM_CAP_SGX_ATTRIBUTE)) {
+        return false;
+    }
+
+    fd = open("/dev/sgx/provision", O_RDONLY);
+    if (fd < 0) {
+        return false;
+    }
+
+    ret = kvm_vm_enable_cap(s, KVM_CAP_SGX_ATTRIBUTE, 0, fd);
+    if (ret) {
+        error_report("Could not enable SGX PROVISIONKEY: %s", strerror(-ret));
+        exit(1);
+    }
+    close(fd);
+    return true;
+}
+
+bool kvm_enable_sgx_provisioning(KVMState *s)
+{
+    return MEMORIZE(__kvm_enable_sgx_provisioning(s), has_sgx_provisioning);
+}
+
 static bool host_supports_vmx(void)
 {
     uint32_t ecx, unused;

--- a/target/i386/kvm_i386.h
+++ b/target/i386/kvm_i386.h
@@ -65,4 +65,7 @@ bool kvm_enable_x2apic(void);
 bool kvm_has_x2apic_api(void);
 
 bool kvm_hv_vpindex_settable(void);
+
+bool kvm_enable_sgx_provisioning(KVMState *s);
+
 #endif


### PR DESCRIPTION
If `--enable-debug` flag is set during configure, a compiler error
occurs due to unmatched prototypes of kvm_enable_sgx_provisioning()
between `target/i386/kvm-stub.c` and `target/i386/kvm_i386.h`.

Compiler error log:
```
  CC      i386-linux-user/target/i386/kvm-stub.o
/home/yum3/qemu-sgx/target/i386/kvm-stub.c:43:6: error: conflicting types for ‘kvm_enable_sgx_provisioning’
 bool kvm_enable_sgx_provisioning(void)
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/yum3/qemu-sgx/target/i386/kvm-stub.c:15:0:
/home/yum3/qemu-sgx/target/i386/kvm_i386.h:69:6: note: previous declaration of ‘kvm_enable_sgx_provisioning’ was here
 bool kvm_enable_sgx_provisioning(KVMState *s);
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/yum3/qemu-sgx/rules.mak:69: recipe for target 'target/i386/kvm-stub.o' failed
make[1]: *** [target/i386/kvm-stub.o] Error 1
Makefile:450: recipe for target 'subdir-i386-linux-user' failed
make: *** [subdir-i386-linux-user] Error 2
```